### PR TITLE
Error about python order

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ i wanted to start a wiki so i made this
 * **Clone** this project
 * **Open** a terminal
 * **Navigate** to the cloned directory
-* **Run** `python -m SimpleHTTPServer 8900`
+* **Run** `python -m http.server 8900`
 * **Browse** to **`localhost:8900`** to use the wiki
 
 ---


### PR DESCRIPTION
When I execute this order:

```bash
python -m SimpleHTTPServer 8900
```

It display:

```bash
No module named SimpleHTTPServer
```

So I googled it and fixed it. You can watch details in this issue https://github.com/Gaotianhe/ideas/issues/177#issue-700524505