### PR TITLE
convert windows paths to posix

### DIFF
--- a/monotome/bin/generate.js
+++ b/monotome/bin/generate.js
@@ -34,6 +34,7 @@ function walk(dir) {
 
 const cwd = process.cwd()
 walk(cwd).then((data) => {
+    data = data.map(data => data.split(path.sep).join(path.posix.sep))
     data.sort((a, b) => a.localeCompare(b)); // sort lexicographically, so that sub-folders are under parent
     var pattern = /(.*\/)+(.*\.md)/
     var ignore = /\..*\/.*/ // ignore folders starting with a period, e.g. `.archives`

--- a/monotome/bin/generate.js
+++ b/monotome/bin/generate.js
@@ -34,7 +34,8 @@ function walk(dir) {
 
 const cwd = process.cwd()
 walk(cwd).then((data) => {
-    data = data.map(data => data.split(path.sep).join(path.posix.sep))
+    if (path.sep != path.posix.sep)
+        data = data.map(data => data.split(path.sep).join(path.posix.sep))
     data.sort((a, b) => a.localeCompare(b)); // sort lexicographically, so that sub-folders are under parent
     var pattern = /(.*\/)+(.*\.md)/
     var ignore = /\..*\/.*/ // ignore folders starting with a period, e.g. `.archives`


### PR DESCRIPTION
I noticed that the generate.js script just creates an empty index on my windows machine. This was due to the path seperator being different, so the pattern matching didn't work. I added a line that converts the paths to posix, if they aren't already in that format.